### PR TITLE
getValue: return node wrapped in array for default case

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,8 @@ const getValue = (j, node) => {
       return [j.identifier(node.name)]
     case 'ObjectExpression':
       return [j.objectExpression(node.properties)]
+    default:
+      return [node]
   }
 }
 


### PR DESCRIPTION
The current implementation of `getValue` does not cover all cases,
for example: `t.true(myMock.called)` will fail, because `getValue`
returns `undefined`.
By addind a `default` case, which just returns the given AST node
wrapped in an array, we can prevent this issue.

Furthermore, we could get rid of `getValue` completely by just wrapping
the given AST node in an array.